### PR TITLE
Fix property name: User.Identify > User.Identity (#27256)

### DIFF
--- a/aspnetcore/fundamentals/use-http-context/samples/Program.cs
+++ b/aspnetcore/fundamentals/use-http-context/samples/Program.cs
@@ -140,7 +140,7 @@ var app = builder.Build();
 
 app.MapGet("/user/current", [Authorize] async (HttpContext context) =>
 {
-    var user = await GetUserAsync(context.User.Identify.Name);
+    var user = await GetUserAsync(context.User.Identity.Name);
     return Results.Ok(user);
 });
 


### PR DESCRIPTION
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

This fix disables the `<Nullable>` setting and will allow the user to create and update database records in SQL Server Local DB. This works in ASP.NET 6 and was originally report by @savionlee in #24541 

So to recap the nullable property in .csproj has been changed from:

```xml
<Nullable>enable</Nullable>
```

```xml
<Nullable>disable</Nullable>
```